### PR TITLE
Handle gracefully when API returns an error

### DIFF
--- a/c14/c14.py
+++ b/c14/c14.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import requests
 import slumber
 
@@ -35,10 +36,22 @@ class C14(object):
         self.api = slumber.API(API_URL,
                                session=api_session, append_slash=False)
 
+    def handle_error(self, exception):
+        content = json.loads(exception.response._content)
+        return {'error': content['error'],
+                'code': content['code'],
+                'status_code': exception.response.status_code,
+                'url': exception.response.url}
+
     def list_platforms(self):
         """Get a list of links to the platforms."""
 
-        return self.api.storage.c14.platform.get()
+        try:
+            res = self.api.storage.c14.platform.get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def get_platform(self, id):
         """Get information on a platform.
@@ -46,12 +59,22 @@ class C14(object):
         :param id: ID of the platform.
         """
 
-        return self.api.storage.c14.platform(id).get()
+        try:
+            res = self.api.storage.c14.platform(id).get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def list_protocols(self):
         """Get a list of available file transfer protocols."""
 
-        return self.api.storage.c14.protocol.get()
+        try:
+            res = self.api.storage.c14.protocol.get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def create_safe(self, name, description=None):
         """Create a safe.
@@ -60,8 +83,13 @@ class C14(object):
         :param description: Description of the safe.
         """
 
-        return self.api.storage.c14.safe.post({'name': name,
-                                               'description': description})
+        try:
+            res = self.api.storage.c14.safe.post({'name': name,
+                                                  'description': description})
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def get_safe(self, uuid):
         """Get information on a safe.
@@ -69,7 +97,12 @@ class C14(object):
         :param uuid: Id of the safe.
         """
 
-        return self.api.storage.c14.safe(uuid).get()
+        try:
+            res = self.api.storage.c14.safe(uuid).get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def update_safe(self, uuid, name=None, description=None):
         """Edit a safe.
@@ -78,13 +111,24 @@ class C14(object):
         :param name: Name of the safe.
         :param description: Description of the safe.
         """
-        return self.api.storage.c14.safe(uuid).patch(name=name,
-                                                     description=description)
+
+        try:
+            res = (self.api.storage.c14.safe(uuid)
+                   .patch(name=name, description=description))
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def list_safes(self):
         """Get a list of links to the user's safes."""
 
-        return self.api.storage.c14.safe.get()
+        try:
+            res = self.api.storage.c14.safe.get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def delete_safe(self, uuid):
         """Delete a safe.
@@ -92,7 +136,12 @@ class C14(object):
         :param uuid: Id of the safe.
         """
 
-        return self.api.storage.c14.safe(uuid).delete()
+        try:
+            res = self.api.storage.c14.safe(uuid).delete()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def create_archive(self, safe_id, name, description, protocols, platforms,
                        parity=None, ssh_keys=None, days=None):
@@ -109,16 +158,21 @@ class C14(object):
                      (2, 5, or 7; default: 7).
         """
 
-        data = {'name': name,
-                'description': description,
-                'parity': parity,
-                'protocols': protocols,
-                'ssh_keys': ssh_keys,
-                'days': days,
-                'platforms': platforms}
+        try:
+            data = {'name': name,
+                    'description': description,
+                    'parity': parity,
+                    'protocols': protocols,
+                    'ssh_keys': ssh_keys,
+                    'days': days,
+                    'platforms': platforms}
 
-        data = dict((k, v) for k, v in data.iteritems() if v is not None)
-        return self.api.storage.c14.safe(safe_id).archive.post(data)
+            data = dict((k, v) for k, v in data.iteritems() if v is not None)
+            res = self.api.storage.c14.safe(safe_id).archive.post(data)
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def get_archive(self, safe_id, uuid):
         """Get information on an Archive.
@@ -127,7 +181,12 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).get()
+        try:
+            res = self.api.storage.c14.safe(safe_id).archive(uuid).get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def update_archive(self, uuid, name=None, description=None):
         """Edit an archive.
@@ -138,8 +197,13 @@ class C14(object):
         :param description: Description of the archive.
         """
 
-        return self.api.storage.c14.safe(uuid).patch(name=name,
-                                                     description=description)
+        try:
+            res = (self.api.storage.c14.safe(uuid)
+                   .patch(name=name, description=description))
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def list_archives(self, safe_id):
         """Get a list of archives in the user's safe.
@@ -147,7 +211,12 @@ class C14(object):
         :param safe_id: Id of the safe.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive.get()
+        try:
+            res = self.api.storage.c14.safe(safe_id).archive.get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def delete_archive(self, safe_id, uuid):
         """Delete an archive.
@@ -156,7 +225,12 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).delete()
+        try:
+            res = self.api.storage.c14.safe(safe_id).archive(uuid).delete()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_archive(self, safe_id, uuid):
         """Archive files from temporary storage.
@@ -165,7 +239,13 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).archive.post()
+        try:
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid).archive
+                   .post())
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_informations(self, safe_id, uuid):
         """Get information on an archive's temporary storage.
@@ -174,7 +254,13 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).bucket.get()
+        try:
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid).bucket
+                   .get())
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_list_jobs(self, safe_id, uuid):
         """Get list of archive jobs.
@@ -183,7 +269,12 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).job.get()
+        try:
+            res = self.api.storage.c14.safe(safe_id).archive(uuid).job.get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_get_job(self, safe_id, uuid, job_id):
         """Get informations of a job.
@@ -193,8 +284,13 @@ class C14(object):
         :param job_id: Id of the job.
         """
 
-        return (self.api.storage.c14.safe(safe_id).archive(uuid).job(job_id)
-                .get())
+        try:
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid)
+                   .job(job_id).get())
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_get_encryption_key(self, safe_id, uuid):
         """Get an archive's encryption key.
@@ -203,7 +299,12 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).key.get()
+        try:
+            res = self.api.storage.c14.safe(safe_id).archive(uuid).key.get()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_set_encryption_key(self, safe_id, uuid, key):
         """Set an archive's encryption key.
@@ -213,8 +314,14 @@ class C14(object):
         :param key: Encryption key.
         """
 
-        data = {'key': key}
-        return self.api.storage.c14.safe(safe_id).archive(uuid).key.post(data)
+        try:
+            data = {'key': key}
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid).key
+                   .post(data))
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_delete_encryption_key(self, safe_id, uuid):
         """Delete an archive's encryption key.
@@ -223,7 +330,12 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).key.delete()
+        try:
+            res = self.api.storage.c14.safe(safe_id).archive(uuid).key.delete()
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_list_locations(self, safe_id, uuid):
         """Get a list of locations on the user's archive.
@@ -232,7 +344,13 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return self.api.storage.c14.safe(safe_id).archive(uuid).location.get()
+        try:
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid).location
+                   .get())
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def archive_get_location(self, safe_id, uuid, location_id):
         """Get information on an archive location.
@@ -241,8 +359,13 @@ class C14(object):
         :param uuid: Id of the archive.
         """
 
-        return (self.api.storage.c14.safe(safe_id).archive(uuid)
-                .location(location_id).get())
+        try:
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid)
+                   .location(location_id).get())
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def verify_archive(self, safe_id, uuid, location_id):
         """Verify the files on an archive's location.
@@ -252,8 +375,13 @@ class C14(object):
         :param location_id: Id of the location.
         """
 
-        return (self.api.storage.c14.safe(safe_id).archive(uuid)
-                .location(location_id).verify.post())
+        try:
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid)
+                   .location(location_id).verify.post())
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res
 
     def unarchive(self, safe_id, uuid, location_id, protocols, rearchive=None,
                   key=None, ssh_keys=None):
@@ -268,12 +396,17 @@ class C14(object):
         :param ssh_keys: UUIDs of SSH keys.
         """
 
-        data = {'location_id': location_id,
-                'protocols': protocols,
-                'rearchive': rearchive,
-                'key': key,
-                'ssh_keys': ssh_keys}
+        try:
+            data = {'location_id': location_id,
+                    'protocols': protocols,
+                    'rearchive': rearchive,
+                    'key': key,
+                    'ssh_keys': ssh_keys}
 
-        data = dict((k, v) for k, v in data.iteritems() if v is not None)
-        return (self.api.storage.c14.safe(safe_id).archive(uuid).unarchive
-                .post(data))
+            data = dict((k, v) for k, v in data.iteritems() if v is not None)
+            res = (self.api.storage.c14.safe(safe_id).archive(uuid).unarchive
+                   .post(data))
+        except slumber.exceptions.HttpClientError as e:
+            res = self.handle_error(e)
+
+        return res


### PR DESCRIPTION
When a user do an action that will raise an error, handle gracefully the
return content from the Online.net API. In order to the user to
understand what happens the following informations are returned:
- error message
- error code (from the api)
- HTTP status code
- URL that was called
